### PR TITLE
fix: loosen pnpm engine checks for Cloudflare

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-engine-strict=true

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"wrangler": "^4.103.0"
 	},
 	"type": "module",
+	"packageManager": "pnpm@11.8.0",
 	"volta": {
 		"node": "22.23.0",
 		"pnpm": "11.8.0"


### PR DESCRIPTION
## Summary
- add packageManager metadata for pnpm 11.8.0
- remove engine-strict so Cloudflare's default pnpm does not fail on transitive package manager engine metadata during install

Cloudflare Pages build image v2 defaults to pnpm 8.7.1 unless PNPM_VERSION is configured, and the install is currently failing on svelte-eslint-parser's pnpm engine metadata.

## Verification
- pnpm install --frozen-lockfile
- pnpm check
- pnpm lint
- pnpm build